### PR TITLE
Add placeholder README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# AI-Enhanced Drug Information Publishing Platform
+
+This repository contains a skeletal implementation for an interview exercise. The goal is to build a production ready system that transforms FDA drug label JSON files into SEO-optimized web pages with the help of AI services.
+
+## Quick Start (under 5 minutes)
+
+1. Install **Node.js 18+**, **Docker**, and **docker-compose**.
+2. Clone this repository.
+3. From the project root run:
+
+   ```bash
+   docker-compose up
+   ```
+
+4. Access the application at `http://localhost:3000`.
+
+> **Note**: The current repository contains only placeholder code. Replace the service implementations and configuration to suit your environment.
+
+## Architecture Overview
+
+The platform is designed as a full-stack application using the following components:
+
+- **Next.js 14+** – Renders drug information pages, performs SEO optimization, and provides the user interface.
+- **NestJS** – Serves as the backend API, processes label data, and exposes an MCP interface.
+- **Python** – Optional scripts for data processing and analysis.
+- **Database** – Stores processed FDA drug label data and AI-enhanced content.
+- **Docker** – Provides a containerized deployment via `docker-compose`.
+
+### Core Workflow
+
+```
+FDA Label JSON → Data Processing → AI Content Enhancement → SEO-Optimized Pages
+```
+
+A data processing pipeline parses each label file, extracts key information, and sends it through AI services for enhanced content generation. The output is then stored in a database and served to the Next.js frontend.
+
+## AI Integration Decisions
+
+- **Service Choice**: `TODO: specify (e.g., OpenAI, Claude)` – pick an API that balances cost, reliability, and medical accuracy.
+- **Reliability**: Implement retries and fallbacks when AI calls fail. Validate generated text before publishing.
+- **Prompting Strategy**: Craft prompts specifically for medical content to minimize hallucinations. See `/docs` for drafting ideas.
+- **MCP Implementation**: Expose drug information and AI tools using the Model Context Protocol.
+
+## SEO Optimization Approach
+
+- Server-side render all drug pages for optimal indexing.
+- Generate meta tags and structured data for each drug.
+- Maintain a clean URL structure (`/drugs/drug-name`).
+- Optimize Core Web Vitals by minimizing client-side JavaScript.
+- Create internal links among related drugs and conditions.
+
+## Performance and Caching
+
+- Cache processed label data to reduce AI API calls and improve page load times.
+- Implement database indices for quick retrieval.
+- Handle AI API rate limits gracefully and log failures for review.
+
+## Known Limitations & Future Work
+
+- The repository currently contains minimal implementation. Key features like AI requests, data models, and a working database are incomplete.
+- Further work is required on automated testing and CI configuration.
+- Additional effort is needed to ensure medical accuracy and regulatory compliance before production use.
+
+## Contributing
+
+1. Fork the repository.
+2. Create a feature branch.
+3. Commit your changes with clear messages.
+4. Open a pull request for review.
+
+---
+
+This README outlines the intended architecture and provides placeholders for the forthcoming implementation of the AI-enhanced drug publishing platform.
+


### PR DESCRIPTION
## Summary
- add README with quick start, architecture, SEO, AI integration and placeholders

## Testing
- `npm test` *(fails: JSONParseError invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685edecc4e9083299fc11fb469a05500