### PR TITLE
Fix SEO route missing from API

### DIFF
--- a/services/api-gateway/src/modules/seo-optimization/seo-optimization.module.ts
+++ b/services/api-gateway/src/modules/seo-optimization/seo-optimization.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { DrugsModule } from '../drugs/drug.module';
 import { SeoOptimizationService } from './services/seo-optimization.service';
 import { SeoOptimizationController } from './controllers/seo-optimization.controller';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, DrugsModule],
   controllers: [SeoOptimizationController],
   providers: [SeoOptimizationService],
   exports: [SeoOptimizationService],


### PR DESCRIPTION
## Summary
- expose drugs module to SEO module
- return SEO metadata by slug on API Gateway
- expose new GET `/seo/drug/:slug` endpoint

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870f48f0a288329977085e907b20bbc