### PR TITLE
Add basic OpenClinica EDC connector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,7 @@ NEXT_PUBLIC_API_URL=http://localhost:3001
 # CORS Configuration (comma-separated list of allowed origins)
 # Update this when deploying to remote server
 CORS_ORIGIN=http://localhost:3000
+
+# OpenClinica Integration
+OPENCLINICA_BASE_URL=http://localhost:8080/OpenClinica
+OPENCLINICA_API_TOKEN=

--- a/services/api-gateway/src/config/edc.config.ts
+++ b/services/api-gateway/src/config/edc.config.ts
@@ -1,0 +1,6 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('edc', () => ({
+  openClinicaUrl: process.env.OPENCLINICA_BASE_URL || 'http://localhost:8080/OpenClinica',
+  openClinicaToken: process.env.OPENCLINICA_API_TOKEN || '',
+}));

--- a/services/api-gateway/src/modules/app.module.ts
+++ b/services/api-gateway/src/modules/app.module.ts
@@ -9,6 +9,7 @@ import { EventEmitterModule } from '@nestjs/event-emitter';
 import appConfig from '../config/app.config';
 import databaseConfig from '../config/database.config';
 import redisConfig from '../config/redis.config';
+import edcConfig from '../config/edc.config';
 
 // Modules
 import { DrugsModule } from './drugs/drug.module';
@@ -19,13 +20,14 @@ import { ProcessingModule } from './processing/processing.module';
 import { SeoOptimizationModule } from './seo-optimization/seo-optimization.module';
 import { WorkflowModule } from './workflow/workflow.module';
 import { EventsModule } from './events/events.module';
+import { EdcModule } from './edc/edc.module';
 
 @Module({
   imports: [
     // Configuration
     ConfigModule.forRoot({
       isGlobal: true,
-      load: [appConfig, databaseConfig, redisConfig],
+      load: [appConfig, databaseConfig, redisConfig, edcConfig],
       envFilePath: ['.env.local', '.env'],
     }),
 
@@ -73,6 +75,7 @@ import { EventsModule } from './events/events.module';
     MCPServerModule,
     EventsModule,
     HealthModule,
+    EdcModule,
   ],
 })
 export class AppModule {}

--- a/services/api-gateway/src/modules/edc/controllers/edc.controller.ts
+++ b/services/api-gateway/src/modules/edc/controllers/edc.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { OpenClinicaService } from '../services/openclinica.service';
+
+@Controller('edc')
+export class EdcController {
+  constructor(private readonly openClinicaService: OpenClinicaService) {}
+
+  @Get('studies')
+  async getStudies() {
+    return this.openClinicaService.getStudies();
+  }
+}

--- a/services/api-gateway/src/modules/edc/edc.module.ts
+++ b/services/api-gateway/src/modules/edc/edc.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { EdcController } from './controllers/edc.controller';
+import { OpenClinicaService } from './services/openclinica.service';
+
+@Module({
+  imports: [ConfigModule],
+  controllers: [EdcController],
+  providers: [OpenClinicaService],
+  exports: [OpenClinicaService],
+})
+export class EdcModule {}

--- a/services/api-gateway/src/modules/edc/services/openclinica.service.ts
+++ b/services/api-gateway/src/modules/edc/services/openclinica.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+
+@Injectable()
+export class OpenClinicaService {
+  private readonly logger = new Logger(OpenClinicaService.name);
+  private readonly baseUrl: string;
+  private readonly token: string;
+
+  constructor(private configService: ConfigService) {
+    this.baseUrl = this.configService.get<string>('edc.openClinicaUrl');
+    this.token = this.configService.get<string>('edc.openClinicaToken');
+  }
+
+  async getStudies(): Promise<any> {
+    try {
+      const response = await axios.get(`${this.baseUrl}/studies`, {
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          Accept: 'application/json',
+        },
+      });
+      return response.data;
+    } catch (error) {
+      this.logger.error('Failed to fetch studies from OpenClinica', error);
+      throw new Error('OpenClinica API request failed');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add env vars for OpenClinica integration
- create edc config
- add edc module with controller and service
- wire edc module and config into the API gateway

## Testing
- `npm install` *(fails: unable to reach registry)*
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fb5ae1ec83299294a661a7e75bbe