### PR TITLE
Add OpenClinica events endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,7 @@ NEXT_PUBLIC_API_URL=http://localhost:3001
 # CORS Configuration (comma-separated list of allowed origins)
 # Update this when deploying to remote server
 CORS_ORIGIN=http://localhost:3000
+
+# OpenClinica Integration
+OPENCLINICA_BASE_URL=http://localhost:8080/OpenClinica
+OPENCLINICA_API_TOKEN=

--- a/README.md
+++ b/README.md
@@ -54,11 +54,14 @@ newgrp docker
    ```bash
    # Copy the example environment file
    cp .env.example .env
-   
+
    # IMPORTANT: Edit .env and add your OpenAI API key
    # The AI features require a valid OpenAI API key to function
    nano .env  # or use your preferred editor
    # Update: OPENAI_API_KEY=your-actual-openai-api-key-here
+   # Optional: configure OpenClinica integration
+   # OPENCLINICA_BASE_URL=http://your-openclinica-instance/OpenClinica
+   # OPENCLINICA_API_TOKEN=your-api-token
    ```
 
 3. **Start with Docker Compose**

--- a/services/api-gateway/src/config/edc.config.ts
+++ b/services/api-gateway/src/config/edc.config.ts
@@ -1,0 +1,6 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('edc', () => ({
+  openClinicaUrl: process.env.OPENCLINICA_BASE_URL || 'http://localhost:8080/OpenClinica',
+  openClinicaToken: process.env.OPENCLINICA_API_TOKEN || '',
+}));

--- a/services/api-gateway/src/modules/app.module.ts
+++ b/services/api-gateway/src/modules/app.module.ts
@@ -9,6 +9,7 @@ import { EventEmitterModule } from '@nestjs/event-emitter';
 import appConfig from '../config/app.config';
 import databaseConfig from '../config/database.config';
 import redisConfig from '../config/redis.config';
+import edcConfig from '../config/edc.config';
 
 // Modules
 import { DrugsModule } from './drugs/drug.module';
@@ -19,13 +20,14 @@ import { ProcessingModule } from './processing/processing.module';
 import { SeoOptimizationModule } from './seo-optimization/seo-optimization.module';
 import { WorkflowModule } from './workflow/workflow.module';
 import { EventsModule } from './events/events.module';
+import { EdcModule } from './edc/edc.module';
 
 @Module({
   imports: [
     // Configuration
     ConfigModule.forRoot({
       isGlobal: true,
-      load: [appConfig, databaseConfig, redisConfig],
+      load: [appConfig, databaseConfig, redisConfig, edcConfig],
       envFilePath: ['.env.local', '.env'],
     }),
 
@@ -73,6 +75,7 @@ import { EventsModule } from './events/events.module';
     MCPServerModule,
     EventsModule,
     HealthModule,
+    EdcModule,
   ],
 })
 export class AppModule {}

--- a/services/api-gateway/src/modules/edc/controllers/edc.controller.ts
+++ b/services/api-gateway/src/modules/edc/controllers/edc.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { OpenClinicaService } from '../services/openclinica.service';
+
+@Controller('edc')
+export class EdcController {
+  constructor(private readonly openClinicaService: OpenClinicaService) {}
+
+  @Get('studies')
+  async getStudies() {
+    return this.openClinicaService.getStudies();
+  }
+
+  @Get('studies/:studyId/events')
+  async getStudyEvents(@Param('studyId') studyId: string) {
+    return this.openClinicaService.getStudyEvents(studyId);
+  }
+}

--- a/services/api-gateway/src/modules/edc/edc.module.ts
+++ b/services/api-gateway/src/modules/edc/edc.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { EdcController } from './controllers/edc.controller';
+import { OpenClinicaService } from './services/openclinica.service';
+
+@Module({
+  imports: [ConfigModule],
+  controllers: [EdcController],
+  providers: [OpenClinicaService],
+  exports: [OpenClinicaService],
+})
+export class EdcModule {}

--- a/services/api-gateway/src/modules/edc/services/openclinica.service.ts
+++ b/services/api-gateway/src/modules/edc/services/openclinica.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+
+@Injectable()
+export class OpenClinicaService {
+  private readonly logger = new Logger(OpenClinicaService.name);
+  private readonly baseUrl: string;
+  private readonly token: string;
+
+  constructor(private configService: ConfigService) {
+    this.baseUrl = this.configService.get<string>('edc.openClinicaUrl');
+    this.token = this.configService.get<string>('edc.openClinicaToken');
+  }
+
+  private async request<T>(endpoint: string): Promise<T> {
+    try {
+      const response = await axios.get(`${this.baseUrl}${endpoint}`, {
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          Accept: 'application/json',
+        },
+      });
+      return response.data;
+    } catch (error) {
+      this.logger.error(`OpenClinica request failed: GET ${endpoint}`, error);
+      throw new Error('OpenClinica API request failed');
+    }
+  }
+
+  async getStudies(): Promise<any> {
+    return this.request('/studies');
+  }
+
+  async getStudyEvents(studyId: string): Promise<any> {
+    return this.request(`/studies/${studyId}/events`);
+  }
+}

--- a/tests/integration/openclinica.service.test.ts
+++ b/tests/integration/openclinica.service.test.ts
@@ -1,0 +1,51 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import edcConfig from '../../services/api-gateway/src/config/edc.config';
+import { OpenClinicaService } from '../../services/api-gateway/src/modules/edc/services/openclinica.service';
+import axios from 'axios';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('OpenClinicaService', () => {
+  beforeEach(() => {
+    mockedAxios.get.mockReset();
+    process.env.OPENCLINICA_BASE_URL = 'http://test-oc';
+    process.env.OPENCLINICA_API_TOKEN = 'token';
+  });
+
+  async function createService(): Promise<OpenClinicaService> {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot({ isGlobal: true, load: [edcConfig] })],
+      providers: [OpenClinicaService],
+    }).compile();
+    return module.get(OpenClinicaService);
+  }
+
+  test('should fetch studies', async () => {
+    const mockData = [{ oid: 'S1' }];
+    mockedAxios.get.mockResolvedValue({ data: mockData });
+    const service = await createService();
+    const result = await service.getStudies();
+
+    expect(mockedAxios.get).toHaveBeenCalledWith('http://test-oc/studies', expect.any(Object));
+    expect(result).toEqual(mockData);
+  });
+
+  test('should fetch study events', async () => {
+    const mockData = [{ name: 'Visit 1' }];
+    mockedAxios.get.mockResolvedValue({ data: mockData });
+    const service = await createService();
+    const result = await service.getStudyEvents('S1');
+
+    expect(mockedAxios.get).toHaveBeenCalledWith('http://test-oc/studies/S1/events', expect.any(Object));
+    expect(result).toEqual(mockData);
+  });
+
+  test('should throw on error', async () => {
+    mockedAxios.get.mockRejectedValue(new Error('Network')); 
+    const service = await createService();
+    await expect(service.getStudies()).rejects.toThrow('OpenClinica API request failed');
+  });
+});


### PR DESCRIPTION
## Summary
- fix `.env.example` newline and add placeholder for OpenClinica token
- document optional OpenClinica config in README
- add endpoint to fetch study events from OpenClinica
- centralize OpenClinica API requests
- test OpenClinica service with mocked axios

## Testing
- `npm install` *(fails: unable to reach registry)*
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fb5ae1ec83299294a661a7e75bbe