### PR TITLE
Add SEO knowledge graph endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A production-ready system that transforms FDA drug label JSON files into SEO-opt
 - 🔍 **Advanced Search**: Full-text search with filters, faceted navigation, and natural language queries
 - 📱 **Responsive Design**: Mobile-first design optimized for healthcare professionals
 - 🎯 **SEO Optimized**: Server-side rendering with structured data and meta tags
+- 🗂️ **Knowledge Graph**: Accessible JSON-LD dataset for search engines at `/knowledge-graph`
 - 💊 **Advanced Drug Comparison**:
   - **SEO-Friendly URLs**: Dynamic URLs with drug names and IDs (e.g., `/drugs/compare?drugs=mounjaro-d2d7da5,olumiant-866e9f3&compare=mounjaro-vs-olumiant`)
   - **Redis Session Storage**: AI comparison results cached for 1 hour with automatic cache checking

--- a/web/src/app/knowledge-graph/route.ts
+++ b/web/src/app/knowledge-graph/route.ts
@@ -1,0 +1,25 @@
+export async function GET() {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://pharmaiq.com'
+  const data = {
+    "@context": "https://schema.org",
+    "@type": "DataCatalog",
+    name: "PharmaIQ Drug Database",
+    description: "Structured data derived from FDA drug labels with AI enhancements.",
+    url: baseUrl,
+    license: "https://creativecommons.org/licenses/by/4.0/",
+    keywords: ["FDA", "drug information", "pharmaceutical", "healthcare"],
+    dataset: {
+      "@type": "Dataset",
+      name: "FDA Drug Labels",
+      url: `${baseUrl}/drugs`,
+      description: "Detailed labeling information for FDA approved drugs."
+    }
+  }
+
+  return new Response(JSON.stringify(data), {
+    headers: {
+      'Content-Type': 'application/ld+json',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600'
+    }
+  })
+}

--- a/web/src/app/robots.txt/route.ts
+++ b/web/src/app/robots.txt/route.ts
@@ -1,6 +1,7 @@
 export async function GET() {
   const robotsTxt = `User-agent: *
 Allow: /
+Allow: /knowledge-graph
 
 Sitemap: ${process.env.NEXT_PUBLIC_BASE_URL || 'https://pharmaiq.com'}/sitemap.xml`
 

--- a/web/src/app/sitemap.xml/route.ts
+++ b/web/src/app/sitemap.xml/route.ts
@@ -41,6 +41,12 @@ export async function GET() {
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
+  <url>
+    <loc>${baseUrl}/knowledge-graph</loc>
+    <lastmod>${new Date().toISOString()}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
   ${drugs.map((drug: any) => `
   <url>
     <loc>${baseUrl}/drugs/${drug.slug}</loc>
@@ -73,6 +79,12 @@ export async function GET() {
     <lastmod>${new Date().toISOString()}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>${baseUrl}/knowledge-graph</loc>
+    <lastmod>${new Date().toISOString()}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
 </urlset>`
 


### PR DESCRIPTION
## Summary
- provide new `/knowledge-graph` route with DataCatalog schema
- list `/knowledge-graph` in sitemap and robots rules
- document knowledge graph endpoint in README

## Testing
- `npx turbo run test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/turbo)*

------
https://chatgpt.com/codex/tasks/task_e_687102086d0083299bb247d7880511d2