### PR TITLE
Integrate OpenClinica data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,4 +46,4 @@ CORS_ORIGIN=http://localhost:3000
 
 # OpenClinica Integration
 OPENCLINICA_BASE_URL=http://localhost:8080/OpenClinica
-OPENCLINICA_API_TOKEN=
+OPENCLINICA_API_TOKEN=your-openclinica-api-token

--- a/services/api-gateway/src/database/entities/edc-study.entity.ts
+++ b/services/api-gateway/src/database/entities/edc-study.entity.ts
@@ -1,0 +1,23 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, Index } from 'typeorm';
+
+@Entity('edc_studies')
+export class EdcStudyEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'oc_study_id', unique: true })
+  @Index()
+  ocStudyId: string;
+
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  status: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/services/api-gateway/src/database/migrations/1704300001000-AddEdcStudies.ts
+++ b/services/api-gateway/src/database/migrations/1704300001000-AddEdcStudies.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddEdcStudies1704300001000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS edc_studies (
+        id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+        oc_study_id VARCHAR(255) NOT NULL UNIQUE,
+        name VARCHAR(255) NOT NULL,
+        status VARCHAR(100),
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS idx_edc_studies_oc_study_id ON edc_studies(oc_study_id)`
+    );
+    await queryRunner.query(`
+      CREATE TRIGGER update_edc_studies_updated_at BEFORE UPDATE ON edc_studies
+      FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TRIGGER IF EXISTS update_edc_studies_updated_at ON edc_studies`);
+    await queryRunner.query(`DROP TABLE IF EXISTS edc_studies`);
+  }
+}

--- a/services/api-gateway/src/modules/edc/edc.module.ts
+++ b/services/api-gateway/src/modules/edc/edc.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { EdcController } from './controllers/edc.controller';
 import { OpenClinicaService } from './services/openclinica.service';
+import { EdcStudyEntity } from '../database/entities/edc-study.entity';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, TypeOrmModule.forFeature([EdcStudyEntity])],
   controllers: [EdcController],
   providers: [OpenClinicaService],
   exports: [OpenClinicaService],

--- a/services/api-gateway/src/modules/edc/services/openclinica.service.ts
+++ b/services/api-gateway/src/modules/edc/services/openclinica.service.ts
@@ -1,6 +1,15 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import axios from 'axios';
+import { EdcStudyEntity } from '../../../database/entities/edc-study.entity';
+
+export interface OpenClinicaStudy {
+  studyOID: string;
+  name: string;
+  status?: string;
+}
 
 @Injectable()
 export class OpenClinicaService {
@@ -8,12 +17,16 @@ export class OpenClinicaService {
   private readonly baseUrl: string;
   private readonly token: string;
 
-  constructor(private configService: ConfigService) {
+  constructor(
+    private configService: ConfigService,
+    @InjectRepository(EdcStudyEntity)
+    private readonly studyRepository: Repository<EdcStudyEntity>,
+  ) {
     this.baseUrl = this.configService.get<string>('edc.openClinicaUrl');
     this.token = this.configService.get<string>('edc.openClinicaToken');
   }
 
-  async getStudies(): Promise<any> {
+  async getStudies(): Promise<OpenClinicaStudy[]> {
     try {
       const response = await axios.get(`${this.baseUrl}/studies`, {
         headers: {
@@ -21,10 +34,34 @@ export class OpenClinicaService {
           Accept: 'application/json',
         },
       });
-      return response.data;
+      const data = response.data?.studies || response.data || [];
+      return data as OpenClinicaStudy[];
     } catch (error) {
       this.logger.error('Failed to fetch studies from OpenClinica', error);
       throw new Error('OpenClinica API request failed');
     }
+  }
+
+  async syncStudies(): Promise<EdcStudyEntity[]> {
+    const studies = await this.getStudies();
+    const saved: EdcStudyEntity[] = [];
+    for (const study of studies) {
+      const existing = await this.studyRepository.findOne({
+        where: { ocStudyId: study.studyOID },
+      });
+      if (existing) {
+        existing.name = study.name;
+        existing.status = study.status;
+        saved.push(await this.studyRepository.save(existing));
+      } else {
+        const entity = this.studyRepository.create({
+          ocStudyId: study.studyOID,
+          name: study.name,
+          status: study.status,
+        });
+        saved.push(await this.studyRepository.save(entity));
+      }
+    }
+    return saved;
   }
 }

--- a/tests/integration/openclinica-sync.test.ts
+++ b/tests/integration/openclinica-sync.test.ts
@@ -1,0 +1,42 @@
+import axios from 'axios';
+import { OpenClinicaService, OpenClinicaStudy } from '../../services/api-gateway/src/modules/edc/services/openclinica.service';
+import { ConfigService } from '@nestjs/config';
+import { Repository } from 'typeorm';
+import { EdcStudyEntity } from '../../services/api-gateway/src/database/entities/edc-study.entity';
+
+jest.mock('axios');
+
+describe('OpenClinicaService syncStudies', () => {
+  const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+  const config = {
+    get: (key: string) => {
+      if (key === 'edc.openClinicaUrl') return 'http://localhost';
+      if (key === 'edc.openClinicaToken') return 'token';
+      return undefined;
+    },
+  } as unknown as ConfigService;
+
+  function createRepo() {
+    return {
+      findOne: jest.fn(),
+      save: jest.fn(entity => Promise.resolve(entity)),
+      create: (e: Partial<EdcStudyEntity>) => ({ ...e } as EdcStudyEntity),
+    } as unknown as Repository<EdcStudyEntity>;
+  }
+
+  test('stores studies from API', async () => {
+    const repo = createRepo();
+    const service = new OpenClinicaService(config, repo);
+    const apiData: { studies: OpenClinicaStudy[] } = {
+      studies: [{ studyOID: 'S1', name: 'Study One', status: 'active' }],
+    };
+    mockedAxios.get.mockResolvedValue({ data: apiData });
+
+    const result = await service.syncStudies();
+
+    expect(repo.save).toHaveBeenCalledTimes(1);
+    expect(result[0].ocStudyId).toBe('S1');
+    expect(result[0].name).toBe('Study One');
+  });
+});


### PR DESCRIPTION
## Summary
- add `edc_studies` entity and migration
- extend OpenClinica service with sync capability
- register new repository in module
- document OpenClinica env vars
- test OpenClinica sync logic

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871028f99708329bc85f1b758938d20