### PR TITLE
Add AI-assisted CRA query resolution

### DIFF
--- a/services/api-gateway/src/modules/app.module.ts
+++ b/services/api-gateway/src/modules/app.module.ts
@@ -21,6 +21,7 @@ import { SeoOptimizationModule } from './seo-optimization/seo-optimization.modul
 import { WorkflowModule } from './workflow/workflow.module';
 import { EventsModule } from './events/events.module';
 import { EdcModule } from './edc/edc.module';
+import { CraModule } from './cra/cra.module';
 
 @Module({
   imports: [
@@ -76,6 +77,7 @@ import { EdcModule } from './edc/edc.module';
     EventsModule,
     HealthModule,
     EdcModule,
+    CraModule,
   ],
 })
 export class AppModule {}

--- a/services/api-gateway/src/modules/cra/controllers/cra.controller.ts
+++ b/services/api-gateway/src/modules/cra/controllers/cra.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, Param, NotFoundException } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { CraService } from '../services/cra.service';
+
+@ApiTags('CRA Workload')
+@Controller('cra')
+export class CraController {
+  constructor(private readonly craService: CraService) {}
+
+  @Get('workloads')
+  getWorkloads() {
+    return this.craService.getAll();
+  }
+
+  @Get('workloads/:id')
+  getWorkload(@Param('id') id: string) {
+    const data = this.craService.getById(id);
+    if (!data) {
+      throw new NotFoundException('CRA not found');
+    }
+    return data;
+  }
+
+  @Get('workloads/:id/suggestions')
+  async getSuggestions(@Param('id') id: string) {
+    return this.craService.suggestQueryResponses(id);
+  }
+}

--- a/services/api-gateway/src/modules/cra/cra.module.ts
+++ b/services/api-gateway/src/modules/cra/cra.module.ts
@@ -1,0 +1,13 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { AIModule } from '../ai/ai.module';
+import { EdcModule } from '../edc/edc.module';
+import { CraController } from './controllers/cra.controller';
+import { CraService } from './services/cra.service';
+
+@Module({
+  imports: [forwardRef(() => AIModule), forwardRef(() => EdcModule)],
+  controllers: [CraController],
+  providers: [CraService],
+  exports: [CraService],
+})
+export class CraModule {}

--- a/services/api-gateway/src/modules/cra/data/sample-workload.json
+++ b/services/api-gateway/src/modules/cra/data/sample-workload.json
@@ -1,0 +1,5 @@
+[
+  {"craId":"CRA001","name":"Alice","openQueries":50,"patientVisits":10,"travelDays":5},
+  {"craId":"CRA002","name":"Bob","openQueries":20,"patientVisits":15,"travelDays":2},
+  {"craId":"CRA003","name":"Charlie","openQueries":90,"patientVisits":8,"travelDays":10}
+]

--- a/services/api-gateway/src/modules/cra/services/cra.service.ts
+++ b/services/api-gateway/src/modules/cra/services/cra.service.ts
@@ -1,0 +1,81 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { AIService } from '../../ai/services/ai.service';
+import { OpenClinicaService, OpenClinicaQuery } from '../../edc/services/openclinica.service';
+import * as path from 'path';
+import * as fs from 'fs';
+
+export interface CRAWorkloadRaw {
+  craId: string;
+  name: string;
+  openQueries: number;
+  patientVisits: number;
+  travelDays: number;
+}
+
+export interface CRAWorkload extends CRAWorkloadRaw {
+  burnoutScore: number;
+  riskLevel: 'low' | 'medium' | 'high';
+}
+
+export interface SuggestedQueryResponse {
+  queryId: string;
+  suggestion: string;
+}
+
+@Injectable()
+export class CraService {
+  private readonly logger = new Logger(CraService.name);
+  private readonly data: CRAWorkloadRaw[];
+
+  constructor(
+    @Optional() private readonly openClinica?: OpenClinicaService,
+    @Optional() private readonly ai?: AIService,
+  ) {
+    const filePath = path.join(__dirname, '../data/sample-workload.json');
+    try {
+      const raw = fs.readFileSync(filePath, 'utf-8');
+      this.data = JSON.parse(raw) as CRAWorkloadRaw[];
+    } catch (error) {
+      this.logger.error(`Failed to load workload data: ${error.message}`);
+      this.data = [];
+    }
+  }
+
+  getAll(): CRAWorkload[] {
+    return this.data.map(d => this.computeWorkload(d));
+  }
+
+  getById(id: string): CRAWorkload | undefined {
+    const item = this.data.find(d => d.craId === id);
+    return item ? this.computeWorkload(item) : undefined;
+  }
+
+  private computeWorkload(data: CRAWorkloadRaw): CRAWorkload {
+    const base = data.openQueries / Math.max(data.patientVisits, 1);
+    const score = parseFloat((base + data.travelDays * 0.1).toFixed(2));
+    let risk: 'low' | 'medium' | 'high' = 'low';
+    if (score > 10) risk = 'high';
+    else if (score > 5) risk = 'medium';
+    return { ...data, burnoutScore: score, riskLevel: risk };
+  }
+
+  async suggestQueryResponses(craId: string): Promise<SuggestedQueryResponse[]> {
+    if (!this.openClinica || !this.ai) {
+      this.logger.warn('OpenClinicaService or AIService not configured');
+      return [];
+    }
+
+    const queries: OpenClinicaQuery[] = await this.openClinica.getOpenQueries(craId);
+    const suggestions: SuggestedQueryResponse[] = [];
+    for (const q of queries) {
+      try {
+        const prompt = `Provide a concise response to the clinical site question: "${q.text}"`;
+        const answer = await this.ai.callOpenAI(prompt, 150);
+        suggestions.push({ queryId: q.queryId, suggestion: answer });
+      } catch (error: any) {
+        this.logger.error(`AI generation failed for query ${q.queryId}`, error);
+      }
+    }
+    return suggestions;
+  }
+}

--- a/services/api-gateway/src/modules/edc/data/sample-queries.json
+++ b/services/api-gateway/src/modules/edc/data/sample-queries.json
@@ -1,0 +1,9 @@
+{
+  "CRA001": [
+    { "queryId": "Q1", "text": "Please clarify visit date for patient 101" },
+    { "queryId": "Q2", "text": "Missing consent form page 2" }
+  ],
+  "CRA002": [
+    { "queryId": "Q3", "text": "Adverse event severity not specified" }
+  ]
+}

--- a/tests/integration/cra-workload.test.ts
+++ b/tests/integration/cra-workload.test.ts
@@ -1,0 +1,33 @@
+import { CraService, SuggestedQueryResponse } from '../../services/api-gateway/src/modules/cra/services/cra.service';
+import { OpenClinicaService, OpenClinicaQuery } from '../../services/api-gateway/src/modules/edc/services/openclinica.service';
+import { AIService } from '../../services/api-gateway/src/modules/ai/services/ai.service';
+
+class MockOpenClinicaService {
+  async getOpenQueries(): Promise<OpenClinicaQuery[]> {
+    return [{ queryId: 'Q1', text: 'Missing date' }];
+  }
+}
+
+class MockAIService {
+  async callOpenAI(): Promise<string> {
+    return 'Use EHR to verify date';
+  }
+}
+
+describe('CRA Workload Service', () => {
+  const service = new CraService(new MockOpenClinicaService() as unknown as OpenClinicaService, new MockAIService() as unknown as AIService);
+
+  it('calculates burnout score and risk level', () => {
+    const cra = service.getById('CRA001');
+    expect(cra).toBeDefined();
+    if (!cra) return;
+    expect(cra.burnoutScore).toBeGreaterThan(0);
+    expect(['low', 'medium', 'high']).toContain(cra.riskLevel);
+  });
+
+  it('suggests responses for open queries', async () => {
+    const suggestions = await service.suggestQueryResponses('CRA001');
+    expect(suggestions.length).toBe(1);
+    expect((suggestions[0] as SuggestedQueryResponse).suggestion).toContain('EHR');
+  });
+});


### PR DESCRIPTION
## Summary
- enhance CRA module with AI-powered query suggestions
- connect CRA module to OpenClinica service for query retrieval
- expose `/cra/workloads/:id/suggestions` endpoint
- add sample OpenClinica queries
- expand integration test for CRA service

## Testing
- `npm test` *(fails: turbo missing)*
- `npx turbo run test` *(fails: network access to install turbo blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687105a11c648329a088522f4e4ba6bb