### PR TITLE
Add OpenClinica events endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,7 @@ NEXT_PUBLIC_API_URL=http://localhost:3001
 # CORS Configuration (comma-separated list of allowed origins)
 # Update this when deploying to remote server
 CORS_ORIGIN=http://localhost:3000
+
+# OpenClinica Integration
+OPENCLINICA_BASE_URL=http://localhost:8080/OpenClinica
+OPENCLINICA_API_TOKEN=your-openclinica-api-token

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A production-ready system that transforms FDA drug label JSON files into SEO-opt
 - 🔍 **Advanced Search**: Full-text search with filters, faceted navigation, and natural language queries
 - 📱 **Responsive Design**: Mobile-first design optimized for healthcare professionals
 - 🎯 **SEO Optimized**: Server-side rendering with structured data and meta tags
+- 🗂️ **Knowledge Graph**: Accessible JSON-LD dataset for search engines at `/knowledge-graph`
 - 💊 **Advanced Drug Comparison**:
   - **SEO-Friendly URLs**: Dynamic URLs with drug names and IDs (e.g., `/drugs/compare?drugs=mounjaro-d2d7da5,olumiant-866e9f3&compare=mounjaro-vs-olumiant`)
   - **Redis Session Storage**: AI comparison results cached for 1 hour with automatic cache checking
@@ -54,11 +55,14 @@ newgrp docker
    ```bash
    # Copy the example environment file
    cp .env.example .env
-   
+
    # IMPORTANT: Edit .env and add your OpenAI API key
    # The AI features require a valid OpenAI API key to function
    nano .env  # or use your preferred editor
    # Update: OPENAI_API_KEY=your-actual-openai-api-key-here
+   # Optional: configure OpenClinica integration
+   # OPENCLINICA_BASE_URL=http://your-openclinica-instance/OpenClinica
+   # OPENCLINICA_API_TOKEN=your-api-token
    ```
 
 3. **Start with Docker Compose**
@@ -714,6 +718,18 @@ npm run db:migrate
 # Seed sample data
 npm run db:seed
 ```
+### Importing OpenFDA Data
+Use the script below to pull labels from the official openFDA API. You can control the API URL, batch size and total records via environment variables or CLI:
+```bash
+# Optional environment overrides
+export OPENFDA_URL="https://api.fda.gov/drug/label.json"
+export OPENFDA_BATCH_SIZE=200   # default 100
+export OPENFDA_TOTAL=5000       # default 1000
+
+# Run import (argument overrides OPENFDA_TOTAL)
+npx ts-node scripts/import-openfda.ts 5000
+```
+
 
 ### AI Processing
 ```bash

--- a/scripts/import-openfda.ts
+++ b/scripts/import-openfda.ts
@@ -1,0 +1,121 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from '../services/api-gateway/src/modules/app.module';
+import { DrugService } from '../services/api-gateway/src/modules/drugs/services/drug.service';
+
+const OPENFDA_URL = process.env.OPENFDA_URL || 'https://api.fda.gov/drug/label.json';
+const DEFAULT_TOTAL = parseInt(process.env.OPENFDA_TOTAL || '1000', 10);
+const BATCH_SIZE = parseInt(process.env.OPENFDA_BATCH_SIZE || '100', 10);
+
+async function fetchWithRetry(url: string, attempts = 3, delay = 1000): Promise<any> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`openFDA request failed: ${res.status} ${res.statusText}`);
+      return await res.json();
+    } catch (err) {
+      if (i === attempts - 1) throw err;
+      const backoff = delay * Math.pow(2, i);
+      console.warn(`Request failed, retrying in ${backoff}ms...`);
+      await new Promise((r) => setTimeout(r, backoff));
+    }
+  }
+}
+
+function buildSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+async function fetchBatch(limit: number, skip: number) {
+  const url = `${OPENFDA_URL}?limit=${limit}&skip=${skip}`;
+  const json = await fetchWithRetry(url, 5);
+  return json.results || [];
+}
+
+function convertRecord(record: any) {
+  const brand = record.openfda?.brand_name?.[0];
+  const generic = record.openfda?.generic_name?.[0];
+  const manufacturer = record.openfda?.manufacturer_name?.[0];
+  const name = brand || generic || 'unknown-drug';
+  if (!brand && !generic) return null;
+  if (!manufacturer) return null;
+  return {
+    drugName: name,
+    setId: record.set_id,
+    slug: buildSlug(name),
+    labeler: manufacturer || 'Unknown',
+    label: {
+      genericName: generic,
+      labelerName: manufacturer,
+      productType: record.openfda?.product_type?.[0],
+      effectiveTime: record.effective_time,
+      title: name,
+      indicationsAndUsage: record.indications_and_usage,
+      dosageAndAdministration: record.dosage_and_administration,
+      dosageFormsAndStrengths: record.dosage_forms_and_strengths,
+      warningsAndPrecautions: record.warnings_and_precautions,
+      adverseReactions: record.adverse_reactions,
+      clinicalPharmacology: record.clinical_pharmacology,
+      clinicalStudies: record.clinical_studies,
+      howSupplied: record.how_supplied,
+      useInSpecificPopulations: record.use_in_specific_populations,
+      description: record.description,
+      nonclinicalToxicology: record.nonclinical_toxicology,
+      instructionsForUse: record.instructions_for_use,
+      mechanismOfAction: record.mechanism_of_action,
+      contraindications: record.contraindications,
+      boxedWarning: record.boxed_warning,
+      drugInteractions: record.drug_interactions,
+    },
+  };
+}
+
+async function run() {
+  const totalArg = process.argv[2];
+  const total = parseInt(totalArg || String(DEFAULT_TOTAL), 10);
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'log'],
+  });
+  const drugService = app.get(DrugService);
+  let fetched = 0;
+  let skip = 0;
+
+  while (fetched < total) {
+    const batch = await fetchBatch(Math.min(BATCH_SIZE, total - fetched), skip);
+    if (batch.length === 0) {
+      break;
+    }
+    for (const item of batch) {
+      const label = convertRecord(item);
+      if (!label) {
+        console.warn(`Skipping incomplete record ${item.set_id}`);
+        continue;
+      }
+      try {
+        await drugService.importDrug({
+          setId: label.setId,
+          drugName: label.drugName,
+          manufacturer: label.labeler,
+          labelData: label,
+        });
+        console.log(`Imported ${label.drugName}`);
+      } catch (err: any) {
+        console.error(`Failed to import ${label.setId}: ${err.message}`);
+      }
+      fetched += 1;
+      if (fetched >= total) break;
+    }
+    skip += batch.length;
+  }
+
+  await app.close();
+}
+
+run().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});
+

--- a/services/api-gateway/src/config/edc.config.ts
+++ b/services/api-gateway/src/config/edc.config.ts
@@ -1,0 +1,6 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('edc', () => ({
+  openClinicaUrl: process.env.OPENCLINICA_BASE_URL || 'http://localhost:8080/OpenClinica',
+  openClinicaToken: process.env.OPENCLINICA_API_TOKEN || '',
+}));

--- a/services/api-gateway/src/database/entities/edc-study.entity.ts
+++ b/services/api-gateway/src/database/entities/edc-study.entity.ts
@@ -1,0 +1,23 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, Index } from 'typeorm';
+
+@Entity('edc_studies')
+export class EdcStudyEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'oc_study_id', unique: true })
+  @Index()
+  ocStudyId: string;
+
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  status: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/services/api-gateway/src/database/migrations/1704300001000-AddEdcStudies.ts
+++ b/services/api-gateway/src/database/migrations/1704300001000-AddEdcStudies.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddEdcStudies1704300001000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS edc_studies (
+        id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+        oc_study_id VARCHAR(255) NOT NULL UNIQUE,
+        name VARCHAR(255) NOT NULL,
+        status VARCHAR(100),
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS idx_edc_studies_oc_study_id ON edc_studies(oc_study_id)`
+    );
+    await queryRunner.query(`
+      CREATE TRIGGER update_edc_studies_updated_at BEFORE UPDATE ON edc_studies
+      FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TRIGGER IF EXISTS update_edc_studies_updated_at ON edc_studies`);
+    await queryRunner.query(`DROP TABLE IF EXISTS edc_studies`);
+  }
+}

--- a/services/api-gateway/src/modules/app.module.ts
+++ b/services/api-gateway/src/modules/app.module.ts
@@ -9,6 +9,7 @@ import { EventEmitterModule } from '@nestjs/event-emitter';
 import appConfig from '../config/app.config';
 import databaseConfig from '../config/database.config';
 import redisConfig from '../config/redis.config';
+import edcConfig from '../config/edc.config';
 
 // Modules
 import { DrugsModule } from './drugs/drug.module';
@@ -19,13 +20,14 @@ import { ProcessingModule } from './processing/processing.module';
 import { SeoOptimizationModule } from './seo-optimization/seo-optimization.module';
 import { WorkflowModule } from './workflow/workflow.module';
 import { EventsModule } from './events/events.module';
+import { EdcModule } from './edc/edc.module';
 
 @Module({
   imports: [
     // Configuration
     ConfigModule.forRoot({
       isGlobal: true,
-      load: [appConfig, databaseConfig, redisConfig],
+      load: [appConfig, databaseConfig, redisConfig, edcConfig],
       envFilePath: ['.env.local', '.env'],
     }),
 
@@ -73,6 +75,7 @@ import { EventsModule } from './events/events.module';
     MCPServerModule,
     EventsModule,
     HealthModule,
+    EdcModule,
   ],
 })
 export class AppModule {}

--- a/services/api-gateway/src/modules/edc/controllers/edc.controller.ts
+++ b/services/api-gateway/src/modules/edc/controllers/edc.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { OpenClinicaService } from '../services/openclinica.service';
+
+@Controller('edc')
+export class EdcController {
+  constructor(private readonly openClinicaService: OpenClinicaService) {}
+
+  @Get('studies')
+  async getStudies() {
+    return this.openClinicaService.getStudies();
+  }
+
+  @Get('studies/:studyId/events')
+  async getStudyEvents(@Param('studyId') studyId: string) {
+    return this.openClinicaService.getStudyEvents(studyId);
+  }
+}

--- a/services/api-gateway/src/modules/edc/edc.module.ts
+++ b/services/api-gateway/src/modules/edc/edc.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { EdcController } from './controllers/edc.controller';
+import { OpenClinicaService } from './services/openclinica.service';
+import { EdcStudyEntity } from '../database/entities/edc-study.entity';
+
+@Module({
+  imports: [ConfigModule, TypeOrmModule.forFeature([EdcStudyEntity])],
+  controllers: [EdcController],
+  providers: [OpenClinicaService],
+  exports: [OpenClinicaService],
+})
+export class EdcModule {}

--- a/services/api-gateway/src/modules/edc/services/openclinica.service.ts
+++ b/services/api-gateway/src/modules/edc/services/openclinica.service.ts
@@ -1,0 +1,75 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import axios from 'axios';
+import { EdcStudyEntity } from '../../../database/entities/edc-study.entity';
+
+export interface OpenClinicaStudy {
+  studyOID: string;
+  name: string;
+  status?: string;
+}
+
+@Injectable()
+export class OpenClinicaService {
+  private readonly logger = new Logger(OpenClinicaService.name);
+  private readonly baseUrl: string;
+  private readonly token: string;
+
+  constructor(
+    private configService: ConfigService,
+    @InjectRepository(EdcStudyEntity)
+    private readonly studyRepository: Repository<EdcStudyEntity>,
+  ) {
+    this.baseUrl = this.configService.get<string>('edc.openClinicaUrl');
+    this.token = this.configService.get<string>('edc.openClinicaToken');
+  }
+
+  private async request<T>(endpoint: string): Promise<T> {
+    try {
+      const response = await axios.get(`${this.baseUrl}${endpoint}`, {
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          Accept: 'application/json',
+        },
+      });
+      return response.data;
+    } catch (error) {
+      this.logger.error(`OpenClinica request failed: GET ${endpoint}`, error);
+      throw new Error('OpenClinica API request failed');
+    }
+  }
+
+  async getStudies(): Promise<OpenClinicaStudy[]> {
+    const data = await this.request<any>('/studies');
+    return data.studies || data;
+  }
+
+  async getStudyEvents(studyId: string): Promise<any> {
+    return this.request(`/studies/${studyId}/events`);
+  }
+
+  async syncStudies(): Promise<EdcStudyEntity[]> {
+    const studies = await this.getStudies();
+    const saved: EdcStudyEntity[] = [];
+    for (const study of studies) {
+      const existing = await this.studyRepository.findOne({
+        where: { ocStudyId: study.studyOID },
+      });
+      if (existing) {
+        existing.name = study.name;
+        existing.status = study.status;
+        saved.push(await this.studyRepository.save(existing));
+      } else {
+        const entity = this.studyRepository.create({
+          ocStudyId: study.studyOID,
+          name: study.name,
+          status: study.status,
+        });
+        saved.push(await this.studyRepository.save(entity));
+      }
+    }
+    return saved;
+  }
+}

--- a/services/api-gateway/src/modules/seo-optimization/seo-optimization.module.ts
+++ b/services/api-gateway/src/modules/seo-optimization/seo-optimization.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { DrugsModule } from '../drugs/drug.module';
 import { SeoOptimizationService } from './services/seo-optimization.service';
 import { SeoOptimizationController } from './controllers/seo-optimization.controller';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, DrugsModule],
   controllers: [SeoOptimizationController],
   providers: [SeoOptimizationService],
   exports: [SeoOptimizationService],

--- a/tests/integration/openclinica-sync.test.ts
+++ b/tests/integration/openclinica-sync.test.ts
@@ -1,0 +1,42 @@
+import axios from 'axios';
+import { OpenClinicaService, OpenClinicaStudy } from '../../services/api-gateway/src/modules/edc/services/openclinica.service';
+import { ConfigService } from '@nestjs/config';
+import { Repository } from 'typeorm';
+import { EdcStudyEntity } from '../../services/api-gateway/src/database/entities/edc-study.entity';
+
+jest.mock('axios');
+
+describe('OpenClinicaService syncStudies', () => {
+  const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+  const config = {
+    get: (key: string) => {
+      if (key === 'edc.openClinicaUrl') return 'http://localhost';
+      if (key === 'edc.openClinicaToken') return 'token';
+      return undefined;
+    },
+  } as unknown as ConfigService;
+
+  function createRepo() {
+    return {
+      findOne: jest.fn(),
+      save: jest.fn(entity => Promise.resolve(entity)),
+      create: (e: Partial<EdcStudyEntity>) => ({ ...e } as EdcStudyEntity),
+    } as unknown as Repository<EdcStudyEntity>;
+  }
+
+  test('stores studies from API', async () => {
+    const repo = createRepo();
+    const service = new OpenClinicaService(config, repo);
+    const apiData: { studies: OpenClinicaStudy[] } = {
+      studies: [{ studyOID: 'S1', name: 'Study One', status: 'active' }],
+    };
+    mockedAxios.get.mockResolvedValue({ data: apiData });
+
+    const result = await service.syncStudies();
+
+    expect(repo.save).toHaveBeenCalledTimes(1);
+    expect(result[0].ocStudyId).toBe('S1');
+    expect(result[0].name).toBe('Study One');
+  });
+});

--- a/tests/integration/openclinica.service.test.ts
+++ b/tests/integration/openclinica.service.test.ts
@@ -1,0 +1,51 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import edcConfig from '../../services/api-gateway/src/config/edc.config';
+import { OpenClinicaService } from '../../services/api-gateway/src/modules/edc/services/openclinica.service';
+import axios from 'axios';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('OpenClinicaService', () => {
+  beforeEach(() => {
+    mockedAxios.get.mockReset();
+    process.env.OPENCLINICA_BASE_URL = 'http://test-oc';
+    process.env.OPENCLINICA_API_TOKEN = 'token';
+  });
+
+  async function createService(): Promise<OpenClinicaService> {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot({ isGlobal: true, load: [edcConfig] })],
+      providers: [OpenClinicaService],
+    }).compile();
+    return module.get(OpenClinicaService);
+  }
+
+  test('should fetch studies', async () => {
+    const mockData = [{ oid: 'S1' }];
+    mockedAxios.get.mockResolvedValue({ data: mockData });
+    const service = await createService();
+    const result = await service.getStudies();
+
+    expect(mockedAxios.get).toHaveBeenCalledWith('http://test-oc/studies', expect.any(Object));
+    expect(result).toEqual(mockData);
+  });
+
+  test('should fetch study events', async () => {
+    const mockData = [{ name: 'Visit 1' }];
+    mockedAxios.get.mockResolvedValue({ data: mockData });
+    const service = await createService();
+    const result = await service.getStudyEvents('S1');
+
+    expect(mockedAxios.get).toHaveBeenCalledWith('http://test-oc/studies/S1/events', expect.any(Object));
+    expect(result).toEqual(mockData);
+  });
+
+  test('should throw on error', async () => {
+    mockedAxios.get.mockRejectedValue(new Error('Network')); 
+    const service = await createService();
+    await expect(service.getStudies()).rejects.toThrow('OpenClinica API request failed');
+  });
+});

--- a/web/src/app/knowledge-graph/route.ts
+++ b/web/src/app/knowledge-graph/route.ts
@@ -1,0 +1,25 @@
+export async function GET() {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://pharmaiq.com'
+  const data = {
+    "@context": "https://schema.org",
+    "@type": "DataCatalog",
+    name: "PharmaIQ Drug Database",
+    description: "Structured data derived from FDA drug labels with AI enhancements.",
+    url: baseUrl,
+    license: "https://creativecommons.org/licenses/by/4.0/",
+    keywords: ["FDA", "drug information", "pharmaceutical", "healthcare"],
+    dataset: {
+      "@type": "Dataset",
+      name: "FDA Drug Labels",
+      url: `${baseUrl}/drugs`,
+      description: "Detailed labeling information for FDA approved drugs."
+    }
+  }
+
+  return new Response(JSON.stringify(data), {
+    headers: {
+      'Content-Type': 'application/ld+json',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600'
+    }
+  })
+}

--- a/web/src/app/robots.txt/route.ts
+++ b/web/src/app/robots.txt/route.ts
@@ -1,6 +1,7 @@
 export async function GET() {
   const robotsTxt = `User-agent: *
 Allow: /
+Allow: /knowledge-graph
 
 Sitemap: ${process.env.NEXT_PUBLIC_BASE_URL || 'https://pharmaiq.com'}/sitemap.xml`
 

--- a/web/src/app/sitemap.xml/route.ts
+++ b/web/src/app/sitemap.xml/route.ts
@@ -41,6 +41,12 @@ export async function GET() {
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
+  <url>
+    <loc>${baseUrl}/knowledge-graph</loc>
+    <lastmod>${new Date().toISOString()}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
   ${drugs.map((drug: any) => `
   <url>
     <loc>${baseUrl}/drugs/${drug.slug}</loc>
@@ -73,6 +79,12 @@ export async function GET() {
     <lastmod>${new Date().toISOString()}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>${baseUrl}/knowledge-graph</loc>
+    <lastmod>${new Date().toISOString()}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
 </urlset>`
 


### PR DESCRIPTION
## Summary
- fix `.env.example` newline and add placeholder for OpenClinica token
- document optional OpenClinica config in README
- add endpoint to fetch study events from OpenClinica
- centralize OpenClinica API requests
- test OpenClinica service with mocked axios
- add trailing newline to `AppModule`
- merge latest `main` and resolve conflicts

## Testing
- `npm install` *(fails to reach registry)*
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fb5ae1ec83299294a661a7e75bbe