### PR TITLE
Implement search analytics and OG image enhancements

### DIFF
--- a/services/api-gateway/src/database/entities/search-log.entity.ts
+++ b/services/api-gateway/src/database/entities/search-log.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('search_logs')
+export class SearchLogEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'text' })
+  query: string;
+
+  @Column({ name: 'result_count', type: 'int' })
+  resultCount: number;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/services/api-gateway/src/database/repositories/search-log.repository.ts
+++ b/services/api-gateway/src/database/repositories/search-log.repository.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SearchLogEntity } from '../entities/search-log.entity';
+
+@Injectable()
+export class SearchLogRepository {
+  constructor(
+    @InjectRepository(SearchLogEntity)
+    private readonly repository: Repository<SearchLogEntity>,
+  ) {}
+
+  async createLog(query: string, resultCount: number): Promise<SearchLogEntity> {
+    const log = this.repository.create({ query, resultCount });
+    return this.repository.save(log);
+  }
+
+  count(): Promise<number> {
+    return this.repository.count();
+  }
+
+  async countDistinctQueries(): Promise<number> {
+    return this.repository
+      .createQueryBuilder('log')
+      .select('COUNT(DISTINCT log.query)', 'count')
+      .getRawOne()
+      .then((r) => parseInt(r.count, 10));
+  }
+
+  async getTopQueries(limit: number): Promise<{ query: string; count: number }[]> {
+    return this.repository
+      .createQueryBuilder('log')
+      .select('log.query', 'query')
+      .addSelect('COUNT(*)', 'count')
+      .groupBy('log.query')
+      .orderBy('count', 'DESC')
+      .limit(limit)
+      .getRawMany();
+  }
+
+  async getNoResultsQueries(limit: number): Promise<{ query: string; count: number }[]> {
+    return this.repository
+      .createQueryBuilder('log')
+      .where('log.result_count = 0')
+      .select('log.query', 'query')
+      .addSelect('COUNT(*)', 'count')
+      .groupBy('log.query')
+      .orderBy('count', 'DESC')
+      .limit(limit)
+      .getRawMany();
+  }
+
+  async getAverageResults(): Promise<number> {
+    const res = await this.repository
+      .createQueryBuilder('log')
+      .select('AVG(log.result_count)', 'avg')
+      .getRawOne();
+    return parseFloat(res.avg) || 0;
+  }
+}

--- a/services/api-gateway/src/modules/events/listeners/search-index.listener.ts
+++ b/services/api-gateway/src/modules/events/listeners/search-index.listener.ts
@@ -1,23 +1,41 @@
 import { Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
+import { ElasticsearchService } from '../../search/services/elasticsearch.service';
+import { DrugRepository } from '../../database/repositories/drug.repository';
 
 @Injectable()
 export class SearchIndexListener {
+  constructor(
+    private readonly elasticsearchService: ElasticsearchService,
+    private readonly drugRepository: DrugRepository,
+  ) {}
+
+  private async indexDrug(drugId: string): Promise<void> {
+    const drug = await this.drugRepository.findBySetId(drugId);
+    if (drug) {
+      try {
+        await this.elasticsearchService.indexDrug(drug);
+        console.log(`Indexed drug ${drugId} in Elasticsearch`);
+      } catch (error) {
+        console.error(`Failed to index drug ${drugId}:`, error);
+      }
+    }
+  }
   @OnEvent('drug.imported')
   async handleDrugImported(payload: { drugId: string; labelData: any }) {
     console.log(`Updating search index for new drug: ${payload.drugId}`);
-    // TODO: Implement search index update logic
+    await this.indexDrug(payload.drugId);
   }
 
   @OnEvent('drug.updated')
   async handleDrugUpdated(payload: { drugId: string }) {
     console.log(`Updating search index for drug: ${payload.drugId}`);
-    // TODO: Implement search index update logic
+    await this.indexDrug(payload.drugId);
   }
 
   @OnEvent('content.enhanced')
   async handleContentEnhanced(payload: { drugId: string }) {
     console.log(`Updating search index for enhanced content: ${payload.drugId}`);
-    // TODO: Implement search index update logic
+    await this.indexDrug(payload.drugId);
   }
 }

--- a/services/api-gateway/src/modules/search/search.module.ts
+++ b/services/api-gateway/src/modules/search/search.module.ts
@@ -5,20 +5,24 @@ import { ElasticsearchService } from './services/elasticsearch.service';
 import { SearchAggregatorService } from './services/search-aggregator.service';
 import { DrugRepository } from '../../database/repositories/drug.repository';
 import { DrugEntity } from '../../database/entities/drug.entity';
+import { SearchLogEntity } from '../../database/entities/search-log.entity';
+import { SearchLogRepository } from '../../database/repositories/search-log.repository';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([DrugEntity]),
+    TypeOrmModule.forFeature([DrugEntity, SearchLogEntity]),
   ],
   controllers: [SearchController],
   providers: [
     ElasticsearchService,
     SearchAggregatorService,
     DrugRepository,
+    SearchLogRepository,
   ],
   exports: [
     ElasticsearchService,
     SearchAggregatorService,
+    SearchLogRepository,
   ],
 })
 export class SearchModule {}

--- a/web/src/app/drugs/[slug]/opengraph-image.tsx
+++ b/web/src/app/drugs/[slug]/opengraph-image.tsx
@@ -15,8 +15,20 @@ interface Props {
 }
 
 export default async function Image({ params }: Props) {
-  // TODO: Fetch drug data
-  const drugName = params.slug.replace(/-/g, ' ').toUpperCase();
+  const apiUrl = process.env.API_GATEWAY_URL || 'http://api:3001';
+  let drugName = params.slug.replace(/-/g, ' ').toUpperCase();
+  let manufacturer = '';
+
+  try {
+    const res = await fetch(`${apiUrl}/drugs/${params.slug}`, { cache: 'no-store' });
+    if (res.ok) {
+      const data = await res.json();
+      drugName = (data.drugName || drugName).toUpperCase();
+      manufacturer = data.manufacturer || '';
+    }
+  } catch (e) {
+    console.error('Failed to fetch drug data for OG image', e);
+  }
 
   return new ImageResponse(
     (
@@ -33,11 +45,14 @@ export default async function Image({ params }: Props) {
           color: 'white',
         }}
       >
-        <div style={{ fontSize: 48, marginBottom: 20 }}>PharmaIQ</div>
-        <div style={{ fontSize: 72, fontWeight: 'bold', textAlign: 'center' }}>
-          {drugName}
-        </div>
-        <div style={{ fontSize: 36, marginTop: 20 }}>Drug Information</div>
+      <div style={{ fontSize: 48, marginBottom: 20 }}>PharmaIQ</div>
+      <div style={{ fontSize: 72, fontWeight: 'bold', textAlign: 'center' }}>
+        {drugName}
+      </div>
+      {manufacturer && (
+        <div style={{ fontSize: 36, marginTop: 20 }}>{manufacturer}</div>
+      )}
+      <div style={{ fontSize: 32, marginTop: 10 }}>Drug Information</div>
       </div>
     ),
     {


### PR DESCRIPTION
## Summary
- log search queries in new `search_logs` table
- add search analytics and popular search retrieval
- keep Elasticsearch index updated via event listener
- enrich dynamic drug OpenGraph images with API data

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68710a98c2d08329a5d9d5f982fe14c9